### PR TITLE
add flexbox property to navigation links

### DIFF
--- a/css-flexbox/css-flexbox_navigation/css/styles.css
+++ b/css-flexbox/css-flexbox_navigation/css/styles.css
@@ -29,3 +29,14 @@ ul {
   padding: 5px 14px;
   border-radius: 5px;
 }
+
+.navigation__menu {
+  display: flex;
+  /* flex-direction: row; */
+  justify-content: space-between;
+  /* align-items: flex-start; */
+  /* align-items: center; */
+}
+
+/* - [ ] The links should be horizontally spaced as far apart as possible.
+- [ ] The first link should be placed at the beginning and the last link at the end. */

--- a/css-flexbox/css-flexbox_navigation/index.html
+++ b/css-flexbox/css-flexbox_navigation/index.html
@@ -11,7 +11,7 @@
     <header class="header">
       <h1>My Personal Website</h1>
       <nav>
-        <ul>
+        <ul class="navigation__menu">
           <li class="navigation__link">
             <a href="#about">About</a>
           </li>


### PR DESCRIPTION
# Context

This PR aims to tackle the [CSS Flexbox Challenge: Navigation](https://github.com/spiced-academy/honey-web-dev/blob/main/sessions/css-flexbox/challenges-css-flexbox.md#flexbox-profile).

# Changes

- [ ] Added a class .navigation__menu to the navigation list items
- [ ] Moved links to be horizontally spaced as far apart as possible.
- [ ] Gave the class a flexbox: display: flex;
- [ ] Made the first link to be placed at the beginning and the last link at the end.
- [ ]  Styled the content: justify-content: space between;

# How to run 
- [ ] n/a